### PR TITLE
husky tests no longer open a browser window when running tests

### DIFF
--- a/clientApp/karma.conf.js
+++ b/clientApp/karma.conf.js
@@ -1,7 +1,7 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
-module.exports = function (config) {
+module.exports = function(config) {
   config.set({
     basePath: '',
     frameworks: ['jasmine', '@angular/cli'],
@@ -12,11 +12,11 @@ module.exports = function (config) {
       require('karma-coverage-istanbul-reporter'),
       require('@angular/cli/plugins/karma')
     ],
-    client:{
+    client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
-      reports: [ 'html', 'lcovonly' ],
+      reports: ['html', 'lcovonly'],
       fixWebpackSourcePaths: true
     },
     angularCli: {
@@ -27,7 +27,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false
+    browsers: ['Chrome', 'ChromeHeadless'],
+    singleRun: false,
+    customLaunchers: {
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: ['--headless', '--disable-gpu', '--no-sandbox', '--remote-debugging-port=9222']
+      }
+    }
   });
 };

--- a/clientApp/package.json
+++ b/clientApp/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
-    "test:once": "ng test --single-run",
+    "test:once": "ng test --single-run --browsers='ChromeHeadless'",
     "lint": "ng lint",
     "format:fix": "pretty-quick --staged",
     "precommit": "run-s format:fix lint test:once",


### PR DESCRIPTION
When people make a commit, the browser no longer opens when the tests are running. It was redundant since it immediately closes when the routine has finished.